### PR TITLE
Correction erreur  optioon button. (non connecté)

### DIFF
--- a/scenes/Home_screen.tscn
+++ b/scenes/Home_screen.tscn
@@ -51,4 +51,4 @@ flat = true
 
 [connection signal="pressed" from="Panel/quit_button" to="." method="_on_quit_button_pressed"]
 [connection signal="pressed" from="Panel/play_button" to="." method="_on_play_button_pressed"]
-[connection signal="pressed" from="Panel/options_button" to="." method="_on_option_button_pressed"]
+[connection signal="pressed" from="Panel/options_button" to="." method="_on_options_button_pressed"]


### PR DESCRIPTION
Correction d'une erreur. Le boutons option était mal connecté (faute de frape) sur l'écran d'accueil. Maintenait problème résolut. 